### PR TITLE
network: Replaced socket-shutdown with socket-close.

### DIFF
--- a/spells/network/compat.sls
+++ b/spells/network/compat.sls
@@ -48,7 +48,7 @@
     (socket-output-port (connection-socket conn)))
 
   (define (close-connection conn)
-    (socket-shutdown (connection-socket conn)))
+    (socket-close (connection-socket conn)))
 
   (define (listener-accept listener)
     (make-connection (socket-accept (listener-socket listener))))


### PR DESCRIPTION
* spells/network/compat.sls (spells): socket-close should be used here
instead of socket-shutdown.